### PR TITLE
fix typo in example

### DIFF
--- a/012_esMultiploDe/description.md
+++ b/012_esMultiploDe/description.md
@@ -1,7 +1,7 @@
 Definir la función ```esMultiploDe/2```, que devuelve ```True``` si el segundo es múltiplo del primero, p.ej.
 
 ```
-Main> esMultiplo 12 3
+Main> esMultiploDe 12 3
 True
 ```
 


### PR DESCRIPTION
The function name 'esMultiplo' was confusing because 'esMultiploDe' was expected
